### PR TITLE
Fixed package import typo in documentation

### DIFF
--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -328,7 +328,7 @@ by going through an identical procedure. ::
   >> from sympy import symbols
   >> from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, outer
   >> from sympy.physics.mechanics import RigidBody, Particle, mechanics_printing
-  >> from symp.physics.mechanics import kinetic_energy, potential_energy, Point
+  >> from sympy.physics.mechanics import kinetic_energy, potential_energy, Point
   >> mechanics_printing()
   >> m, M, l1, g, h, H = symbols('m M l1 g h H')
   >> omega = dynamicsymbols('omega')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
There was a tiny typo (`symp` instead of `sympy`) in the example code for the "Masses, Inertias, Particles and Rigid Bodies in Physics/Mechanics" docs. This fixes it. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* docs
  * fix typo in physics documentation code snippet

<!-- END RELEASE NOTES -->
